### PR TITLE
feat: add the input "strict"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ npx
 
 Please see [action.yaml](action.yaml) too.
 
+### `strict`
+
+required: false
+
+The input was introduced from v1.0.0.
+Either `true` of `false`.
+If it's `true`, renovate-config-validator's --strict option is set.
+The default is `true`.
+
 ### `validator_version`
 
 required: false
@@ -66,6 +75,7 @@ steps:
     with:
       validator_version: "31.15.0"
       config_file_path: renovate.json5
+      strict: "false"
 ```
 
 ## Liencse

--- a/action.yaml
+++ b/action.yaml
@@ -50,8 +50,8 @@ runs:
         fi
 
         if [ -n "$CONFIG_FILE_PATH" ]; then
-          echo "===> RENOVATE_CONFIG_FILE=\"$CONFIG_FILE_PATH\" npx --package \"$pkg\" -c renovate-config-validator $opts" >&2
-          RENOVATE_CONFIG_FILE="$CONFIG_FILE_PATH" npx --package "$pkg" -c renovate-config-validator $opts
+          echo "===> RENOVATE_CONFIG_FILE=\"$CONFIG_FILE_PATH\" npx --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
+          RENOVATE_CONFIG_FILE="$CONFIG_FILE_PATH" npx --package "$pkg" -c "renovate-config-validator $opts"
           exit 0
         fi
 
@@ -59,8 +59,8 @@ runs:
         for file in .github/renovate.json .github/renovate.json5 .gitlab/renovate.json .gitlab/renovate.json5 .renovaterc.json .renovaterc.json5 renovate.json renovate.json5 .renovaterc; do
           if [ -f "$file" ]; then
             missing=false
-            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --package \"$pkg\" -c renovate-config-validator $opts" >&2
-            RENOVATE_CONFIG_FILE="$file" npx --package "$pkg" -c renovate-config-validator $opts
+            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
+            RENOVATE_CONFIG_FILE="$file" npx --package "$pkg" -c "renovate-config-validator $opts"
           fi
         done
         if [ "$missing" = "true" ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,10 @@ description: |
   Validate Renovate Configuration with renovate-config-validator.
   npx is required.
 inputs:
+  strict:
+    description: Either true of false. If it's true, renovate-config-validator's --strict option is set
+    default: "true"
+    required: false
   validator_version:
     description: version of renovate-config-validator. By default, the latest version is used.
     required: false
@@ -30,21 +34,33 @@ runs:
   steps:
     - name: Validate Renovate Configuration with renovate-config-validator
       run: |
+        set -eu
         pkg=renovate
+
+        opts=""
+        if [ "$STRICT" = "true" ]; then
+          opts=--strict
+        elif [ "$STRICT" != "false" ]; then
+          echo '::error:: the input 'strict' must be "true" or "false"'
+          exit 1
+        fi
+
         if [ -n "$VALIDATOR_VERSION" ]; then
           pkg="renovate@$VALIDATOR_VERSION"
         fi
+
         if [ -n "$CONFIG_FILE_PATH" ]; then
-          echo "===> RENOVATE_CONFIG_FILE=\"$CONFIG_FILE_PATH\" npx --package \"$pkg\" -c renovate-config-validator" >&2
-          RENOVATE_CONFIG_FILE="$CONFIG_FILE_PATH" npx --package "$pkg" -c renovate-config-validator
+          echo "===> RENOVATE_CONFIG_FILE=\"$CONFIG_FILE_PATH\" npx --package \"$pkg\" -c renovate-config-validator $opts" >&2
+          RENOVATE_CONFIG_FILE="$CONFIG_FILE_PATH" npx --package "$pkg" -c renovate-config-validator $opts
           exit 0
         fi
+
         missing=true
         for file in .github/renovate.json .github/renovate.json5 .gitlab/renovate.json .gitlab/renovate.json5 .renovaterc.json .renovaterc.json5 renovate.json renovate.json5 .renovaterc; do
           if [ -f "$file" ]; then
             missing=false
-            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --package \"$pkg\" -c renovate-config-validator" >&2
-            RENOVATE_CONFIG_FILE="$file" npx --package "$pkg" -c renovate-config-validator
+            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --package \"$pkg\" -c renovate-config-validator $opts" >&2
+            RENOVATE_CONFIG_FILE="$file" npx --package "$pkg" -c renovate-config-validator $opts
           fi
         done
         if [ "$missing" = "true" ]; then
@@ -54,3 +70,4 @@ runs:
       env:
         VALIDATOR_VERSION: ${{inputs.validator_version}}
         CONFIG_FILE_PATH: ${{inputs.config_file_path}}
+        STRICT: ${{inputs.strict}}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "github>aquaproj/aqua-renovate-config#1.13.0"
   ],
   "automerge": true,


### PR DESCRIPTION
## Features

Add the input `strict`.
You can enable renovate-config-validator's `--strict` option.

## ⚠️ Breaking Changes

renovate-config-validator's `--strict` option is enabled by default.

### How to migrate

There are several options.

1. Recommended: Fix Renovate configuration according to the error message
2. Unrecommended: Set `false` to the input `strict` to disable `--strict` option