### PR TITLE
feat: support multiple files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,13 @@ jobs:
         run: |
           set -euo pipefail
           files=$(git ls-files | grep renovate.json)
-          echo "files=$files" >> "$GITHUB_OUTPUT"
+          # https://stackoverflow.com/a/74232400
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "files<<$EOF"
+            echo "$files"
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Pass files through output
         uses: ./
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,3 +12,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./
+      - name: Test a single file
+        uses: ./
+        with:
+          config_file_path: renovate.json
+      - name: Test multiple files
+        uses: ./
+        with:
+          config_file_path: |
+            renovate.json
+            tests/renovate.json
+      - id: files
+        run: |
+          set -euo pipefail
+          files=$(git ls-files | grep renovate.json)
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+      - name: Pass files through output
+        uses: ./
+        with:
+          config_file_path: ${{ steps.files.outputs.files }}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,36 @@ By default, the following files are validated.
 * renovate.json5
 * .renovaterc
 
+If you want to validate multiple files, you can pass multile lines.
+Leading spaces on each line are removed.
+
+```yaml
+with:
+  config_file_path: |
+    default.json
+    foo.json
+```
+
+You can pass `config_file_path` through output command.
+
+```yaml
+      - id: files
+        run: |
+          set -euo pipefail
+          files=$(git ls-files | grep renovate.json)
+          # https://stackoverflow.com/a/74232400
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "files<<$EOF"
+            echo "$files"
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Pass files through output
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
+        with:
+          config_file_path: ${{ steps.files.outputs.files }}
+```
+
 ## Output
 
 Nothing.

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,7 @@ runs:
         fi
 
         if [ -n "$CONFIG_FILE_PATH" ]; then
+          IFS='\n'
           for file in "$(echo "$CONFIG_FILE_PATH")"; do
             echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
             RENOVATE_CONFIG_FILE="$file" npx --yes --package "$pkg" -c "renovate-config-validator $opts"

--- a/action.yaml
+++ b/action.yaml
@@ -52,11 +52,13 @@ runs:
         fi
 
         if [ -n "$CONFIG_FILE_PATH" ]; then
-          IFS='\n'
-          for file in "$(echo "$CONFIG_FILE_PATH")"; do
+          while read -r file; do
+            if [ -z "$file" ]; then
+              continue
+            fi
             echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
             RENOVATE_CONFIG_FILE="$file" npx --yes --package "$pkg" -c "renovate-config-validator $opts"
-          done
+          done < <(echo "$CONFIG_FILE_PATH")
           exit 0
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,8 @@ inputs:
       - renovate.json
       - renovate.json5
       - .renovaterc
+
+      You can specify multiple files by multiple lines.
     required: false
 runs:
   using: composite
@@ -50,8 +52,10 @@ runs:
         fi
 
         if [ -n "$CONFIG_FILE_PATH" ]; then
-          echo "===> RENOVATE_CONFIG_FILE=\"$CONFIG_FILE_PATH\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
-          RENOVATE_CONFIG_FILE="$CONFIG_FILE_PATH" npx --yes --package "$pkg" -c "renovate-config-validator $opts"
+          for file in "$(echo "$CONFIG_FILE_PATH")"; do
+            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
+            RENOVATE_CONFIG_FILE="$file" npx --yes --package "$pkg" -c "renovate-config-validator $opts"
+          done
           exit 0
         fi
 

--- a/tests/renovate.json
+++ b/tests/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:best-practices"
+  ]
+}


### PR DESCRIPTION
Close #699

e.g.

```yaml
  - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.0
    with:
      config_file_path: |
        renovate.json5
        default.json
```

You can pass the list through output.

e.g.

```yaml
      - id: files
        run: |
          set -euo pipefail
          files=$(git ls-files | grep renovate.json)
          # https://stackoverflow.com/a/74232400
          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
          {
            echo "files<<$EOF"
            echo "$files"
            echo "$EOF"
          } >> "$GITHUB_OUTPUT"
      - name: Pass files through output
        uses: ./
        with:
          config_file_path: ${{ steps.files.outputs.files }}
```