### PR TITLE
fix: workaround for strict not failing when using RENOVATE_CONFIG_FILE

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ runs:
         if [ "$STRICT" = "true" ]; then
           opts=--strict
         elif [ "$STRICT" != "false" ]; then
-          echo '::error:: the input 'strict' must be "true" or "false"'
+          echo "::error:: the input 'strict' must be \"true\" or \"false\""
           exit 1
         fi
 
@@ -56,22 +56,24 @@ runs:
             if [ -z "$file" ]; then
               continue
             fi
-            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
-            RENOVATE_CONFIG_FILE="$file" npx --yes --package "$pkg" -c "renovate-config-validator $opts"
+            echo "===> npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts $file\"" >&2
+            npx --yes --package "$pkg" -c "renovate-config-validator $opts $file"
           done < <(echo "$CONFIG_FILE_PATH")
           exit 0
-        fi
+        else
 
-        missing=true
-        for file in .github/renovate.json .github/renovate.json5 .gitlab/renovate.json .gitlab/renovate.json5 .renovaterc.json .renovaterc.json5 renovate.json renovate.json5 .renovaterc; do
-          if [ -f "$file" ]; then
-            missing=false
-            echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
-            RENOVATE_CONFIG_FILE="$file" npx --yes --package "$pkg" -c "renovate-config-validator $opts"
+          missing=true
+          for file in .github/renovate.json .github/renovate.json5 .gitlab/renovate.json .gitlab/renovate.json5 .renovaterc.json .renovaterc.json5 renovate.json renovate.json5 .renovaterc; do
+            if [ -f "$file" ]; then
+              missing=false
+              echo "===> npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts $file\"" >&2
+              echo "===> RENOVATE_CONFIG_FILE=\"$file\" npx --yes --package \"$pkg\" -c \"renovate-config-validator $opts\"" >&2
+              npx --yes --package "$pkg" -c "renovate-config-validator $opts $file"
+            fi
+          done
+          if [ "$missing" = "true" ]; then
+            echo "===> No configuration file is found" >&2
           fi
-        done
-        if [ "$missing" = "true" ]; then
-          echo "===> No configuration file is found" >&2
         fi
       shell: bash
       env:


### PR DESCRIPTION
Related to https://github.com/suzuki-shunsuke/github-action-renovate-config-validator/issues/768
Verified strict now exits with a non-zero code so the action will fail if there is a migration.  
The quoting was giving me issues so I changed it (verified with shellcheck).
Not sure about my change on the logic on when config files are passed or not, seemed like if one is passed the usual location could be skipped, but maybe that was intentional.