### PR TITLE
fix: always use @latest to refresh cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,9 +47,7 @@ runs:
           exit 1
         fi
 
-        if [ -n "$VALIDATOR_VERSION" ]; then
-          pkg="renovate@$VALIDATOR_VERSION"
-        fi
+        pkg="renovate@${VALIDATOR_VERSION:-latest}"
 
         if [ -n "$CONFIG_FILE_PATH" ]; then
           files=$(echo "$CONFIG_FILE_PATH" | tr '\n' ' ')


### PR DESCRIPTION
I was running into a bug you filed back at https://github.com/renovatebot/renovate/discussions/38261.

It turns out that if you don't specify `@latest`, npx will use any cached versions on a system. In my case, there's an npx cache being automatically populated by GitHub! See this example run where the version is a few major versions old:

https://github.com/deviantintegral/har/actions/runs/21037826230/job/60490701799#step:3:56