### PR TITLE
feat: install Node.js 24 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 
 GitHub Actions for renovate-config-validator
 
-## Requirement
+## :rocket: Recent Update
 
-npx
+- v2.0.0: Node.js 24 is installed by default to support the latest Renovate
 
 ## Input
 
 Please see [action.yaml](action.yaml) too.
+
+## `node-version`
+
+required: false
+
+The input was introduced from v2.0.0.
+As of v2.0.0, this action installs Node.js using actions/setup-node by default.
+If `node-version` is `none`, the installation is skipped.
+We started installing Node.js by default because the Node.js version which is pre-installed into GitHub Actions `ubuntu-latest` runner is old (v20) and doesn't support the latest Renovate.
 
 ### `strict`
 

--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,12 @@ description: |
   Validate Renovate Configuration with renovate-config-validator.
   npx is required.
 inputs:
+  node-version:
+    description: |
+      Node.js version. If the version is "none", the node installation is skipped.
+      The version must be compatible with the version of Renovate.
+    default: "24"
+    required: false
   strict:
     description: Either true of false. If it's true, renovate-config-validator's --strict option is set
     default: "true"
@@ -34,6 +40,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      if: inputs.node-version != 'none'
+      with:
+        node-version: ${{inputs.node-version}}
     - name: Validate Renovate Configuration with renovate-config-validator
       run: |
         set -eu


### PR DESCRIPTION
## ⚠️ Breaking Change

The action installs Node.js 24 by default.
If you don't want to install it, please set the input `node-version` to `none`.

## Why?

To support the latest Renovate by default.